### PR TITLE
Multi stage

### DIFF
--- a/QueueDown/MultiStagePipes.cs
+++ b/QueueDown/MultiStagePipes.cs
@@ -1,0 +1,84 @@
+using System.Buffers;
+using System.Collections.Immutable;
+using System.IO.Pipelines;
+
+namespace QueueDown;
+
+public static class MultiStagePipes
+{
+    public class PipeGroup
+    {
+        private ImmutableArray<PipeReader> _readers = ImmutableArray<PipeReader>.Empty;
+
+        public ImmutableArray<PipeReader> Readers => _readers;
+
+
+        public void AddPipe(PipeReader reader)
+        {
+            ImmutableInterlocked.Update(ref _readers, static (array, arg) => array.Add(arg), reader);
+        }
+
+        public void RemovePipe(PipeReader reader)
+        {
+            ImmutableInterlocked.Update(ref _readers, static (array, arg) => array.Remove(arg), reader);
+        }
+    }
+
+    public static void Run(Pipe outputPipe, List<Task> tasks, MemoryPool<byte> pool)
+    {
+        PipeGroup readers = new();
+
+        for (int i = 0; i < 50; i++) {
+            var __ = Task.Run(async () => {
+                var producerPipe = new Pipe(new(pool));
+                readers.AddPipe(producerPipe.Reader);
+
+
+                // Write to the pipe
+                while (true) {
+                    var buffer = producerPipe.Writer.GetMemory();
+                    buffer.Span.Fill((byte)i);
+                    producerPipe.Writer.Advance(buffer.Length);
+                    await producerPipe.Writer.FlushAsync();
+                }
+            });
+        }
+
+        var _ = Task.Run(() => ReadAllPipes(readers, outputPipe.Writer));
+    }
+
+    static async Task ReadAllPipes(PipeGroup stage1Pipes, PipeWriter outputPipe)
+    {
+        while (true) {
+            var pipes = stage1Pipes.Readers;
+
+            foreach (var inputPipe in pipes) 
+            {
+                if (inputPipe.TryRead(out var result)) 
+                {
+                    var inputBuffer = result.Buffer;
+
+                    if (inputBuffer.IsSingleSegment) 
+                    {
+                        outputPipe.Write(result.Buffer.FirstSpan);
+                    } 
+                    else 
+                    {
+                        foreach (var segment in result.Buffer) {
+                            outputPipe.Write(segment.Span);
+                        }
+                    }
+                    
+                    var flushResult = await outputPipe.FlushAsync();
+
+                    inputPipe.AdvanceTo(inputBuffer.End);
+
+                    if (result.IsCompleted || flushResult.IsCompleted) {
+                        stage1Pipes.RemovePipe(inputPipe);
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/QueueDown/Program.cs
+++ b/QueueDown/Program.cs
@@ -15,7 +15,7 @@ partial class Program
         var pipe = new Pipe(new(pool));
         var tasks = new List<Task>();
         
-        MultiStagePipes.Run(pipe, tasks, pool);
+        MultiStagePipes.Run(pipe, pool);
 
         Pipes4(pipe, tasks, pool);
         // Pipes3(pipe, tasks, pool);

--- a/QueueDown/Program.cs
+++ b/QueueDown/Program.cs
@@ -17,7 +17,7 @@ partial class Program
         
         MultiStagePipes.Run(pipe, pool);
 
-        Pipes4(pipe, tasks, pool);
+        //Pipes4(pipe, tasks, pool);
         // Pipes3(pipe, tasks, pool);
         // Pipes2(pipe, tasks, pool);
         // Pipes(pipe, tasks, pool);

--- a/QueueDown/Program.cs
+++ b/QueueDown/Program.cs
@@ -8,10 +8,14 @@ partial class Program
 {
     static async Task Main(string[] args)
     {
+        Console.WriteLine("Running...");
+        
         // This is the memory pool from Kestrel
         var pool = new PinnedBlockMemoryPool();
         var pipe = new Pipe(new(pool));
         var tasks = new List<Task>();
+        
+        MultiStagePipes.Run(pipe, tasks, pool);
 
         Pipes4(pipe, tasks, pool);
         // Pipes3(pipe, tasks, pool);
@@ -54,10 +58,10 @@ public class ServiceEventSource : EventSource
     {
         if (command.Command == EventCommand.Enable)
         {
-            _invocationRateCounter = new IncrementingPollingCounter("transfer-rate", this, () => Volatile.Read(ref _bytesConsumed))
+            _invocationRateCounter = new IncrementingPollingCounter("transfer-rate", this, () => Volatile.Read(ref _bytesConsumed) / (1024 * 1024))
             {
                 DisplayRateTimeScale = TimeSpan.FromSeconds(1),
-                DisplayUnits = "B"
+                DisplayUnits = "MB"
             };
         }
     }


### PR DESCRIPTION
This is kind of messy, but here is a 2-stage pipe approach that seems to perform well. The idea is to reduce write contention by giving each worker it's own pipe. A single reader then pushes into the final pipe. 

You could also use a fixed number (M) of pipes and then 'load balance' the (N) workers into them. This version simples sets M=N. 

This also fixes the counter to write in MB which prevents the output from switching to scientific notation 

Non-scientific measurements
```
MultiStage =    transfer-rate (MB / 1 sec)                                 6,097 //most recent push
Pipes4     =    transfer-rate (MB / 1 sec)                                 3,297
Pipes3     =    transfer-rate (MB / 1 sec)                                 4,056
Pipe2      =    transfer-rate (MB / 1 sec)                                 1,525 
Pipes      =    transfer-rate (MB / 1 sec)                                 3,206 
Semaphores =    transfer-rate (MB / 1 sec)                                 1,597
Channles   =    transfer-rate (MB / 1 sec)                                 3,331

```

